### PR TITLE
TensorFlow 1.14+

### DIFF
--- a/tensorflow/build_tensorflow_1.14.sh
+++ b/tensorflow/build_tensorflow_1.14.sh
@@ -110,31 +110,11 @@ git checkout $ARG_VERSION
 
 GCC_PREFIX=$(dirname $(dirname $(which gcc)))
 if [[ $ARG_GPU == 1 ]]; then
-    sed -i "s/which('ldconfig')/which('echo')/g" configure.py
+    sed -i "s/which(\"ldconfig\")/which('echo')/g" third_party/gpus/find_cuda_config.py
 
-    sed -i "s;-B/usr/bin;-B$EBROOTGCC/bin;g" third_party/gpus/cuda_configure.bzl
-
-    RPATH_TO_ADD="$EBROOTCUDNN/lib64 $(find $EBROOTCUDA -name lib64) $EBROOTIMKL/compilers_and_libraries/linux/lib/intel64_lin"
-    CROSSTOOL_FILE=third_party/gpus/crosstool/cc_toolchain_config.bzl.tpl
- 
-    for path in $RPATH_TO_ADD; do
-        sed -i "\;flag: \"-Wl,-no-as-needed\"; a \ \ \ \ \ \ \ \ flag: \"-Wl,-rpath=$path\"" $CROSSTOOL_FILE
-    done
-
-    sed -i "\;%{linker_bin_path_flag}; a \ \ \ \ \ \ \ \ flag: \"-B$EBROOTGCC/lib/\"" $CROSSTOOL_FILE
-
-    sed -i "\;linking_mode_flags { mode: DYNAMIC }; a \
-\ \ cxx_builtin_include_directory: \"/cvmfs/soft.computecanada.ca/nix/var/nix/profiles/gcc-7.3.0/lib/gcc/x86_64-pc-linux-gnu/7.3.0/include/\"" $CROSSTOOL_FILE
-    sed -i "\;linking_mode_flags { mode: DYNAMIC }; a \
-\ \ cxx_builtin_include_directory: \"/cvmfs/soft.computecanada.ca/nix/var/nix/profiles/gcc-7.3.0/lib/gcc/x86_64-pc-linux-gnu/7.3.0/include-fixed/\"" $CROSSTOOL_FILE
-    sed -i "\;linking_mode_flags { mode: DYNAMIC }; a \
-\ \ cxx_builtin_include_directory: \"/cvmfs/soft.computecanada.ca/nix/var/nix/profiles/gcc-7.3.0/include/c++/7.3.0/\"" $CROSSTOOL_FILE
-    # look for tools
-    for tool in $(grep 'tool_path { .* }' $CROSSTOOL_FILE | grep -Po '(?<=path: ")([a-z\/]{1,})'); do
-        toolname=$(basename $tool)
-        new_path=$(which $toolname)
-        sed -i "s;$tool;$new_path;g" $CROSSTOOL_FILE
-    done
+    sed -i "\;host_compiler_includes = get_cxx_inc_directories;a \ \ \ \ host_compiler_includes += \[\"/cvmfs/soft.computecanada.ca/nix/var/nix/profiles/gcc-7.3.0/lib/gcc/x86_64-pc-linux-gnu/7.3.0/include/\"\]" third_party/gpus/cuda_configure.bzl
+    sed -i "\;host_compiler_includes = get_cxx_inc_directories;a \ \ \ \ host_compiler_includes += \[\"/cvmfs/soft.computecanada.ca/nix/var/nix/profiles/gcc-7.3.0/lib/gcc/x86_64-pc-linux-gnu/7.3.0/include-fixed/\"\]" third_party/gpus/cuda_configure.bzl
+    sed -i "\;host_compiler_includes = get_cxx_inc_directories;a \ \ \ \ host_compiler_includes += \[\"/cvmfs/soft.computecanada.ca/nix/var/nix/profiles/gcc-7.3.0/include/c++/7.3.0/\"\]" third_party/gpus/cuda_configure.bzl
 fi
 
 #sed -i -r "/libiomp5/d" third_party/mkl/mkl.BUILD
@@ -185,6 +165,7 @@ cc_library(
 EOF
     # Add dependency to third_party library
     git apply $SCRIPT_DIR/rdma.patch
+    git apply $SCRIPT_DIR/tensorflow-1.14-mpi.patch
     # TF 1.11.0 ISSUE 21999
     #git cherry-pick -n c67ded664a20f27b4e90020bf76a097b462182b1
     #git apply $SCRIPT_DIR/tensorflow-mpi.patch
@@ -200,11 +181,12 @@ EOF
     TF_NEED_MPI=1 \
     TF_NEED_GDR=1 \
     TF_NEED_VERBS=1 \
+    GCC_HOST_COMPILER_PREFIX="$EBROOTNIXPKGS/bin" \
     GCC_HOST_COMPILER_PATH=$(which mpicc) \
     TF_NCCL_VERSION="$EBVERSIONNCCL" \
     NCCL_INSTALL_PATH="$EBROOTNCCL" \
     MPI_HOME="$EBROOTOPENMPI"
-    CONFIG_XOPT="--config cuda"
+#    CONFIG_XOPT="--config cuda"
 else
     export \
     TF_NEED_CUDA=0 \
@@ -249,7 +231,7 @@ bazel \
     --output_user_root=$BAZEL_ROOT_PATH \
     build \
         --jobs $N_JOBS \
-        --action_env=LD_LIBRARY_PATH=/usr/lib64/nvidia \
+        --action_env=LD_LIBRARY_PATH=$EBROOTCUDA/lib64 \
         --verbose_failures \
         --config opt \
         --config mkl \
@@ -263,6 +245,7 @@ WHEEL_REBUILD_FOLDER=$(mktemp -d -p .)
 TARGET_WHEEL=$(ls -Art $OPWD/*.whl | tail -n 1)
 cd $WHEEL_REBUILD_FOLDER
 unzip $TARGET_WHEEL 
+chmod -R 777 *.data
 find . -name libiomp5.so -delete
 sed -i 's/libiomp5.so//g' *.dist-info/RECORD
 
@@ -273,8 +256,14 @@ if [[ $ARG_CCAPI == 1 ]] ; then
     cp $TF_COMPILE_PATH/tensorflow/bazel-bin/tensorflow/libtensorflow_cc.so *.data/purelib/tensorflow/
 fi
 
-# Fix missing NCCL link paths
+# Add runtime paths
 setrpaths.sh --path *.data --add_path $EBROOTNCCL/lib
+setrpaths.sh --path *.data --add_path $EBROOTCUDNN/lib64
+for path in $(find $EBROOTCUDA -name lib64)
+do
+   setrpaths.sh --path *.data --add_path $path
+done
+
 zip -r $TARGET_WHEEL *.data/ *.dist-info/
 cd ..
 rm -rf $WHEEL_REBUILD_FOLDER

--- a/tensorflow/tensorflow-1.14-mpi.patch
+++ b/tensorflow/tensorflow-1.14-mpi.patch
@@ -1,0 +1,29 @@
+From 498e35a3bfe38dd75cf1416a1a23c07c3b59e6af Mon Sep 17 00:00:00 2001
+From: Bas Aarts <baarts@nvidia.com>
+Date: Tue, 11 Jun 2019 16:50:20 -0700
+Subject: [PATCH] Compiling TensorFlow when configured with CUDA and MPI
+ support results in compilation failure:
+
+tensorflow/contrib/mpi_collectives/kernels/ring.cu.cc(110): error: identifier "CudaLaunchKernel" is undefined
+
+tensorflow/contrib/mpi_collectives/kernels/ring.cu.cc(111): error: identifier "CudaLaunchKernel" is undefined
+
+tensorflow/contrib/mpi_collectives/kernels/ring.cu.cc(112): error: identifier "CudaLaunchKernel" is undefined
+
+Include tensorflow/core/util/gpu_kernel_helper.h in ring.cu.cc to pull in declaartion of CudaLaunchKernel
+---
+ tensorflow/contrib/mpi_collectives/kernels/ring.cu.cc | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/tensorflow/contrib/mpi_collectives/kernels/ring.cu.cc b/tensorflow/contrib/mpi_collectives/kernels/ring.cu.cc
+index c8e3e81c8baa..6b55b01d67d0 100644
+--- a/tensorflow/contrib/mpi_collectives/kernels/ring.cu.cc
++++ b/tensorflow/contrib/mpi_collectives/kernels/ring.cu.cc
+@@ -21,6 +21,7 @@ limitations under the License.
+ 
+ #include "tensorflow/contrib/mpi_collectives/kernels/ring.h"
+ #include "tensorflow/core/util/gpu_launch_config.h"
++#include "tensorflow/core/util/gpu_kernel_helper.h"
+ 
+ namespace tensorflow {
+ namespace contrib {


### PR DESCRIPTION
`third_party/gpus/cuda_configure.bzl` now accepts an environment variable `GCC_HOST_COMPILER_PREFIX` which alleviates the need to replace the linker flags and tooling paths. Note that `GCC_HOST_COMPILER_PREFIX` in our case would point to the NIXPKGS bin directory for `ld`, `ar`, etc. The actual location of gcc is still defined by `GCC_HOST_COMPILER_PATH`.

I now patch the include directories directly in `cuda_configure.bzl`. It's weird these aren't included already because `gcc` should provide these? See: https://github.com/tensorflow/tensorflow/blob/v2.0.0-beta1/third_party/gpus/cuda_configure.bzl#L285 where it attempts to get the include directories straight from the compiler.