### PR TITLE
Rename TMPDIR to TEMP_DIR for unmanylinuxize.sh.

### DIFF
--- a/unmanylinuxize.sh
+++ b/unmanylinuxize.sh
@@ -12,9 +12,9 @@ else
 	PACKAGE_DOWNLOAD_ARGUMENT="$PACKAGE"
 fi
 
-TMPDIR=tmp.$$
-mkdir $TMPDIR
-cd $TMPDIR
+TEMP_DIR=tmp.$$
+mkdir $TEMP_DIR
+cd $TEMP_DIR
 for pv in $PYTHON_VERSIONS; do
 	module load $pv
 	PYTHONPATH= pip download --no-deps $PACKAGE_DOWNLOAD_ARGUMENT
@@ -25,4 +25,4 @@ for w in *.whl; do
 done
 mv *.whl ..
 cd ..
-rm -rf $TMPDIR
+rm -rf $TEMP_DIR


### PR DESCRIPTION
On national systems, TMPDIR is set to /tmp and this causes
issues for the mktemp call in setrpaths.sh.