### PR TITLE
make build_wheel.sh find all patch files in patches dir

### DIFF
--- a/build_wheel.sh
+++ b/build_wheel.sh
@@ -280,12 +280,13 @@ for pv in $PYTHON_VERSIONS; do
 	log_command pushd $PACKAGE_FOLDER_NAME* || log_command pushd *
 	echo "=============================="
 
+	PATCHESDIR=$(dirname $0)/patches
 	if [[ ! -z "$PATCHES" ]]; then
 		echo "=============================="
 		echo "Patching"
 		for p in $PATCHES;
 		do
-			log_command patch --verbose -p1 < $p > /dev/null
+			log_command patch --verbose -p1 < ${PATCHESDIR}/$p > /dev/null
 		done
 		echo "Patching done"
 		echo "=============================="

--- a/config/foyer.sh
+++ b/config/foyer.sh
@@ -1,3 +1,3 @@
 MODULE_RUNTIME_DEPS="intel/2018.3 openmpi/3.1.2 openmm/7.4.1"
 PYTHON_DEPS="ParmEd networkx lark-parser requests lxml"
-PATCHES="$CONFIGDIR/../patches/foyer-0.7.4.patch"
+PATCHES="foyer-0.7.4.patch"

--- a/config/llvmlite.sh
+++ b/config/llvmlite.sh
@@ -1,3 +1,3 @@
 PYTHON_DEPS="enum34"
 MODULE_BUILD_DEPS="llvm cuda/10.1 tbb"
-PATCHES="$PWD/patches/llvmlite-0.28.0-fpic.patch"
+PATCHES="llvmlite-0.28.0-fpic.patch"

--- a/config/mbuild.sh
+++ b/config/mbuild.sh
@@ -1,3 +1,3 @@
 MODULE_RUNTIME_DEPS="intel/2018.3 openmpi/3.1.2 packmol/18.013"
 PYTHON_DEPS="oset ParmEd mdtraj pandas"
-PATCHES="$CONFIGDIR/../patches/mbuild-0.10.5.patch"
+PATCHES="mbuild-0.10.5.patch"

--- a/config/minieigen.sh
+++ b/config/minieigen.sh
@@ -1,4 +1,3 @@
 MODULE_BUILD_DEPS="gcc/7.3.0 openmpi/3.1.2 boost/1.68.0 eigen/3.3.5"
 MODULE_RUNTIME_DEPS="gcc/7.3.0 eigen/3.3.5"
-PATCHES="$CONFIGDIR/../patches/minieigen-0.5.4-boost1.68.0_libs.patch"
-
+PATCHES="minieigen-0.5.4-boost1.68.0_libs.patch"

--- a/config/roboschool.sh
+++ b/config/roboschool.sh
@@ -8,5 +8,4 @@ if [[ "$RSNT_ARCH" == "avx2" ]]; then
 elif [[ "$RSNT_ARCH" == "avx512" ]]; then
 	export CFLAGS="-march=skylake-avx512"
 fi
-PATCHES="$PWD/patches/roboschool-cpp-household.patch"
-
+PATCHES="roboschool-cpp-household.patch"


### PR DESCRIPTION
This makes it easier to write config files (because one only needs to list the filenames) 
and "build_wheel.sh" can be called from the PATH.

The mechanism is analoge to how the location of CONFIGDIR is determined.