### PR TITLE
Use explicit arch/sse3 for numpy/scipy wheels.

### DIFF
--- a/build_wheel.sh
+++ b/build_wheel.sh
@@ -381,9 +381,15 @@ if [[ -z "$EBROOTGENTOO" ]]; then
 	module load nixpkgs gcc/7.3.0
 else
 	ARCH_TO_LOAD="$EBVERSIONARCH"
+	# Figure out cheaply if the wheel needs an arch module to build
+	for mod in $MODULE_BUILD_DEPS; do
+		if [[ "${mod##arch/}" != "$mod" ]]; then
+		       ARCH_TO_LOAD="${mod##arch/}"
+		fi
+	done
 	module --force purge
 	# if there are module dependencies, we really should build with our primary architecture rather than the compatibility one
-	if [[ -n "$MODULE_BUILD_DEPS" && -n "$MODULE_RUNTIME_DEPS" ]]; then
+	if [[ -z "$MODULE_BUILD_DEPS" && -z "$MODULE_RUNTIME_DEPS" ]]; then
 		module load arch/${ARCH_TO_LOAD:-sse3}
 	else
 		module load arch/${ARCH_TO_LOAD:-avx2}

--- a/config/numpy.sh
+++ b/config/numpy.sh
@@ -1,9 +1,5 @@
 PRE_BUILD_COMMANDS='module load flexiblas/3.0.4; echo "[DEFAULT]" > site.cfg; echo "library_dirs = $EBROOTFLEXIBLAS/lib" >> site.cfg; echo "include_dirs = $EBROOTFLEXIBLAS/include/flexiblas" >> site.cfg; echo "[atlas]" >> site.cfg; echo "atlas_libs = flexiblas" >> site.cfg; echo "[lapack]" >> site.cfg; echo "lapack_libs = flexiblas" >> site.cfg'
-if [[ -z $EBROOTGENTOO ]]; then
-	MODULE_BUILD_DEPS="imkl/2019.2.187"
-else
-	MODULE_BUILD_DEPS="flexiblas/3.0.4"
-fi
+MODULE_BUILD_DEPS="arch/sse3 flexiblas/3.0.4"
 PYTHON_DEPS="nose pytest cython hypothesis"
 PYTHON_DEPS_DEFAULT=""
 PYTHON_TESTS="numpy.__config__.show(); numpy.test()"

--- a/config/scipy.sh
+++ b/config/scipy.sh
@@ -1,4 +1,4 @@
-MODULE_BUILD_DEPS="flexiblas/3.0.4"
+MODULE_BUILD_DEPS="arch/sse3 flexiblas/3.0.4"
 PYTHON_DEPS_DEFAULT=""
 PYTHON_DEPS="numpy pytest pybind11 cython pythran"
 PYTHON_TESTS="scipy.__config__.show(); scipy.test()"


### PR DESCRIPTION
Since those are generic but only have arch-independent dependencies
they need some special treatment.