### PR TITLE
Reactivate the virtual environment for testing.

### DIFF
--- a/build_wheel.sh
+++ b/build_wheel.sh
@@ -346,12 +346,14 @@ function test_whl()
 {
 	echo "=============================="
 	echo "Testing..."
+	deactivate
 	if [[ -n "$MODULE_BUILD_DEPS" ]]; then
 		module unload $MODULE_BUILD_DEPS
 	fi
 	if [[ -n "$MODULE_RUNTIME_DEPS" ]]; then
 		module load $MODULE_RUNTIME_DEPS
 	fi
+	source build_$PVDIR/bin/activate
 	log_command module list
 	echo "Installing wheel"
 	wrapped_pip_install ../$WHEEL_NAME


### PR DESCRIPTION
With arch/sse3 in $MODULE_BUILD_DEPS, module unload messes up $PATH,
so the main pip/python executables have priority over the virtual env
ones. This caused it to install the wheel under $HOME/.local with
all kinds of strange effects.