### PR TITLE
Check for arch-specific wheels when copying generic wheels

### DIFF
--- a/cp_wheels.sh
+++ b/cp_wheels.sh
@@ -4,20 +4,23 @@ WHEELHOUSE_ROOT="/cvmfs/soft.computecanada.ca/custom/python/wheelhouse"
 
 function print_usage
 {
-	echo "Usage: $0 [--wheel <wheel file>] [--remove] [--dry-run]"
+	echo "Usage: $0 [--wheel <wheel_file>] [--arch generic|<rsnt_arch>] [--remove] [--dry-run]"
 }
 
-TEMP=$(getopt -o h --longoptions help,remove,dry-run,wheel: --name $0 -- "$@")
+TEMP=$(getopt -o h --longoptions help,remove,dry-run,arch:,wheel: --name $0 -- "$@")
 if [ $? != 0 ] ; then print_usage; exit 1 ; fi
 eval set -- "$TEMP"
 
 ARG_WHEEL=""
+ARC_ARCH=""
 ARG_REMOVE=""
 ARG_DRY_RUN=""
 while true; do
 	case "$1" in
 		--wheel)
 			ARG_WHEEL=$2; shift 2;;
+		--arch)
+			ARG_ARCH=$2; shift 2;;
 		--remove)
 			ARG_REMOVE=1; shift 1;;
 		--dry-run)
@@ -42,6 +45,26 @@ function cp_wheel {
 		echo "Run the following for more details: "
 		echo "bash wheel_architecture.sh $NAME"
 		exit
+	fi
+	if [[ "$ARG_ARCH" != "" ]]; then
+		ARCHITECTURE="$ARG_ARCH"
+	fi
+	if [[ ! "$ARCHITECTURE" =~ ^(generic|sse3|avx|avx2|avx512)$ ]]; then
+		echo "Error, unknown architecture: $ARCHITECTURE"
+		exit
+	fi
+	if [[ "$ARCHITECTURE" == "generic" && "$ARG_ARCH" == "" ]]; then
+		PKGNAME="${NAME%%-*}"
+		ARCH_WHEELS="$(find $WHEELHOUSE_ROOT -not -wholename "*/generic/*" -name "$PKGNAME-*.whl" -printf "%P\n")"
+		if [[ "$ARCH_WHEELS" != "" ]]; then
+			echo "Error, the following arch-specific wheels already exist in the wheelhouse:"
+			for w in $ARCH_WHEELS; do
+				echo "  $w"
+			done
+			echo "$NAME cannot be copied as a generic wheel."
+			echo "Use --arch <rsnt_arch> to specify the architecture."
+			exit
+		fi
 	fi
 	echo chmod ug+rw,o+r $1
 	if [[ "$ARG_DRY_RUN" == "" ]]; then
@@ -82,5 +105,3 @@ fi
 for w in $WHEEL_LIST; do
         cp_wheel $w $(bash wheel_architecture.sh $w 2>/dev/null) $ARG_REMOVE
 done
-
-


### PR DESCRIPTION
Some wheels are incorrectly detected as generic by
`wheel_architecture.sh` because they have no dependencies on external
packages but contain C extensions or bundled libraries that use SIMD.

To detect this, `cp_wheels.sh` now checks for existing wheels (same
package name) in the wheelhouse that are in arch-specific locations.
If any are found, `cp_wheels.sh` refuses to copy the wheel to a
generic location. The architecture can be specified with the new
`--arch` option.