### PR TITLE
Copy new arch-specific wheels with generic compat to gentoo/<arch>

### DIFF
--- a/cp_wheels.sh
+++ b/cp_wheels.sh
@@ -66,6 +66,9 @@ function cp_wheel {
 			exit
 		fi
 	fi
+	if [[ "$COMPAT" == "generic" && "$ARCHITECTURE" != "generic" ]]; then
+		COMPAT=gentoo
+	fi
 	echo chmod ug+rw,o+r $1
 	if [[ "$ARG_DRY_RUN" == "" ]]; then
 		chmod ug+rw,o+r $1

--- a/cp_wheels.sh
+++ b/cp_wheels.sh
@@ -67,6 +67,11 @@ function cp_wheel {
 		fi
 	fi
 	if [[ "$COMPAT" == "generic" && "$ARCHITECTURE" != "generic" ]]; then
+		# Wheels that include C extensions but have no dependencies on
+		# external libraries are detected for the generic compatibility
+		# layer but can still be arch-specific if they make use of SIMD
+		# instructions. In that case, we put them in gentoo since new
+		# wheels might be incompatible with the older glibc in Nix.
 		COMPAT=gentoo
 	fi
 	echo chmod ug+rw,o+r $1


### PR DESCRIPTION
This avoids a corner-case bug where an arch-specific wheel still ends up in `generic` because its compatibility layer is detected as `generic`. We copy to `gentoo/<arch>` rather than `<arch>` (symlink to `nix/<arch>`) since new wheels are likely not compatible with the older glibc in Nix.