### PR TITLE
Manip wheel version fix

### DIFF
--- a/build_wheel.sh
+++ b/build_wheel.sh
@@ -388,6 +388,10 @@ function test_whl()
 
 function adjust_numpy_requirements_based_on_link_info()
 {
+	# don't modify numpy wheels themselves
+	if [[ $WHEEL_NAME =~ numpy-.* ]]; then
+		return
+	fi
 	# only linux_x86_64 wheels will contain .so'
 	if [[ $WHEEL_NAME =~ .*linux_x86_64.* ]]; then
 		cwd=$(pwd)

--- a/build_wheel.sh
+++ b/build_wheel.sh
@@ -313,7 +313,11 @@ function build()
 		sed -i -e "s/name='$PACKAGE'/name='$PACKAGE$PACKAGE_SUFFIX'/g" $(find . -name "setup.py")
 	fi
 	echo "Building the wheel...."
-	$PYTHON_CMD setup.py bdist_wheel $BDIST_WHEEL_ARGS &> build.log
+	if [[ -f "setup.py" ]]; then
+		$PYTHON_CMD setup.py bdist_wheel $BDIST_WHEEL_ARGS &> build.log
+	elif [[ -f "pyproject.toml" ]]; then
+		log_command pip wheel . &> build.log
+	fi
 	if [[ $? -ne 0 ]]; then
 		echo "An error occured."
 		echo "Build log is in $(pwd)/build.log"

--- a/build_wheel.sh
+++ b/build_wheel.sh
@@ -81,7 +81,7 @@ PRE_BUILD_COMMANDS_DEFAULT='sed -i -e "s/\([^\.]\)distutils.core/\1setuptools/g"
 PYTHON_DEPS_DEFAULT="numpy~=1.21.2 scipy cython"
 
 PYTHON27_ONLY="cogent OBITools gdata qcli emperor RSeQC preprocess Amara pysqlite IPTest ipaddress functools32 blmath bamsurgeon"
-if [[ $PYTHON27_ONLY =~ $PACKAGE ]]; then
+if [[ $PYTHON27_ONLY =~ " $PACKAGE " ]]; then
 	PYTHON_VERSIONS="python/2.7"
 fi
 

--- a/build_wheel.sh
+++ b/build_wheel.sh
@@ -78,7 +78,9 @@ PATCHES=""
 PACKAGE_DOWNLOAD_CMD="pip download -v --no-cache --no-binary \$PACKAGE --no-use-pep517 --no-deps \$PACKAGE_DOWNLOAD_ARGUMENT"
 PRE_BUILD_COMMANDS_DEFAULT='sed -i -e "s/\([^\.]\)distutils.core/\1setuptools/g" setup.py'
 
-PYTHON_DEPS_DEFAULT="numpy~=1.21.2 scipy cython"
+NUMPY_DEFAULT_VERSION=1.21.2
+
+PYTHON_DEPS_DEFAULT="numpy~=$NUMPY_DEFAULT_VERSION scipy cython"
 
 PYTHON27_ONLY="cogent OBITools gdata qcli emperor RSeQC preprocess Amara pysqlite IPTest ipaddress functools32 blmath bamsurgeon"
 if [[ $PYTHON27_ONLY =~ " $PACKAGE " ]]; then

--- a/build_wheel.sh
+++ b/build_wheel.sh
@@ -404,6 +404,7 @@ function adjust_numpy_requirements_based_on_link_info()
 		if [[ $num_links -gt 0 ]]; then
 			numpy_build_version=$(pip show numpy | grep Version | awk '{print $2}' | sed -e "s/\([0-9]\.[0-9]*\)\..*/\1/g")
 			echo "Found $num_links shared objects that mention a specific version of API of numpy. Pinning the minimum required version of numpy to $numpy_build_version"
+			log_command $SCRIPT_DIR/manipulate_wheels.py --inplace --force --wheels $cwd/../$WHEEL_NAME --set_min_numpy $numpy_build_version
 		fi
 	fi
 }

--- a/config/Bottleneck.sh
+++ b/config/Bottleneck.sh
@@ -1,3 +1,3 @@
-PYTHON_DEPS="numpy nose pytest"
+PYTHON_DEPS="numpy~=$NUMPY_DEFAULT_VERSION nose pytest"
 PYTHON_TESTS="bottleneck.test();" # bottleneck.bench()"
 

--- a/config/GPy.sh
+++ b/config/GPy.sh
@@ -1,2 +1,2 @@
-PYTHON_DEPS="numpy matplotlib"
+PYTHON_DEPS="numpy~=$NUMPY_DEFAULT_VERSION matplotlib"
 

--- a/config/HTSeq.sh
+++ b/config/HTSeq.sh
@@ -1,2 +1,2 @@
-PYTHON_DEPS="numpy Cython pysam"
+PYTHON_DEPS="numpy~=$NUMPY_DEFAULT_VERSION Cython pysam"
 

--- a/config/MDAnalysis.sh
+++ b/config/MDAnalysis.sh
@@ -1,4 +1,4 @@
-PYTHON_DEPS="gsd Cython joblib numpy mock GridDataFormats scipy matplotlib networkx biopython mmtf-python six duecredit"
+PYTHON_DEPS="gsd Cython joblib numpy~=$NUMPY_DEFAULT_VERSION mock GridDataFormats scipy matplotlib networkx biopython mmtf-python six duecredit"
 # keyword "provides" makes problems with wheelfile package [1]
 # and is also ignored by pip [2], so we just comment it out.
 # [1] https://github.com/MrMino/wheelfile/issues/13

--- a/config/MetaPhlAn.sh
+++ b/config/MetaPhlAn.sh
@@ -1,4 +1,4 @@
-PYTHON_DEPS="numpy biopython biom_format matplotlib scipy"
+PYTHON_DEPS="numpy~=$NUMPY_DEFAULT_VERSION biopython biom_format matplotlib scipy"
 MODULE_BUILD_DEPS="gcc/7.3.0 bowtie2/2.3.5.1 scipy-stack/2019b glpk/4.65"
 PACKAGE_DOWNLOAD_ARGUMENT="https://files.pythonhosted.org/packages/3c/44/8c1297f88361cf16e1d160921d96c12b40de1d4f4a636b60b19a857e6d08/MetaPhlAn-{VERSION}.tar.gz"
 PACKAGE_DOWNLOAD_NAME="MetaPhlAn-{VERSION}.tar.gz"

--- a/config/Theano.sh
+++ b/config/Theano.sh
@@ -1,2 +1,2 @@
-PYTHON_DEPS="numpy scipy six"
+PYTHON_DEPS="numpy~=$NUMPY_DEFAULT_VERSION scipy six"
 

--- a/config/amico.sh
+++ b/config/amico.sh
@@ -1,5 +1,5 @@
 
-PYTHON_DEPS="numpy dipy scipy nibabel h5py six"
+PYTHON_DEPS="numpy~=$NUMPY_DEFAULT_VERSION dipy scipy nibabel h5py six"
 PACKAGE_DOWNLOAD_ARGUMENT="https://github.com/daducci/AMICO/archive/master.zip"
 PACKAGE_DOWNLOAD_NAME="master.zip"
 PACKAGE_FOLDER_NAME="AMICO-master"

--- a/config/anvio.sh
+++ b/config/anvio.sh
@@ -1,3 +1,3 @@
-PYTHON_DEPS="numpy Cython statsmodels==0.9.0"
+PYTHON_DEPS="numpy~=$NUMPY_DEFAULT_VERSION Cython statsmodels==0.9.0"
 MODULE_BUILD_DEPS="gcc/5.4.0 gsl/2.3"
 

--- a/config/arboretum.sh
+++ b/config/arboretum.sh
@@ -1,2 +1,2 @@
-PYTHON_DEPS="numpy scipy scikit-learn pandas dask distributed"
+PYTHON_DEPS="numpy~=$NUMPY_DEFAULT_VERSION scipy scikit-learn pandas dask distributed"
 

--- a/config/astropy.sh
+++ b/config/astropy.sh
@@ -1,6 +1,6 @@
 PACKAGE="astropy"
 PYTHON_IMPORT_NAME=$PACKAGE
 PACKAGE_FOLDER_NAME=$PACKAGE
-PYTHON_DEPS="cython numpy scipy networkx torch extension_helpers jinja2"
+PYTHON_DEPS="cython numpy~=$NUMPY_DEFAULT_VERSION scipy networkx torch extension_helpers jinja2"
 #TEST_COMMAND="python -c import astropy;astropy.test()"
 PYTHON_TESTS="astropy.test()"

--- a/config/basemap-1.2.0.sh
+++ b/config/basemap-1.2.0.sh
@@ -3,7 +3,7 @@ PACKAGE_DOWNLOAD_NAME="v1.2.0rel.tar.gz"
 PRE_BUILD_COMMANDS="sed -i \"s/__version__ = '1.1.0'/__version__ = '1.2.0'/\"  lib/mpl_toolkits/basemap/__init__.py"
 PACKAGE_FOLDER_NAME="basemap-${VERSION}"
 MODULE_BUILD_DEPS="proj geos"
-PYTHON_DEPS="numpy matplotlib pyproj pyshp python-dateutil"
+PYTHON_DEPS="numpy~=$NUMPY_DEFAULT_VERSION matplotlib pyproj pyshp python-dateutil"
 PRE_DOWNLOAD_COMMANDS="export GEOS_DIR=${EBROOTGEOS} "
 PYTHON_IMPORT_NAME="mpl_toolkits.basemap"
 

--- a/config/basemap.sh
+++ b/config/basemap.sh
@@ -2,7 +2,7 @@ PACKAGE_DOWNLOAD_ARGUMENT="https://github.com/matplotlib/basemap/archive/v${VERS
 PACKAGE_DOWNLOAD_NAME="v${VERSION}.tar.gz"
 PACKAGE_FOLDER_NAME="basemap-${VERSION}"
 MODULE_BUILD_DEPS="proj geos"
-PYTHON_DEPS="numpy matplotlib pyproj pyshp python-dateutil"
+PYTHON_DEPS="numpy~=$NUMPY_DEFAULT_VERSION matplotlib pyproj pyshp python-dateutil"
 PRE_DOWNLOAD_COMMANDS="export GEOS_DIR=${EBROOTGEOS} "
 PYTHON_IMPORT_NAME="mpl_toolkits.basemap"
 

--- a/config/biopython.sh
+++ b/config/biopython.sh
@@ -1,3 +1,3 @@
 MODULE_BUILD_DEPS="scipy-stack/2020b"
-PYTHON_DEPS="nose numpy six Cython unittest2 scipy sympy"
+PYTHON_DEPS="nose numpy~=$NUMPY_DEFAULT_VERSION six Cython unittest2 scipy sympy"
 PYTHON_IMPORT_NAME="Bio"

--- a/config/blis.sh
+++ b/config/blis.sh
@@ -1,4 +1,4 @@
-PYTHON_DEPS="numpy cython pytest hypothesis wheel"
+PYTHON_DEPS="numpy~=$NUMPY_DEFAULT_VERSION cython pytest hypothesis wheel"
 #PRE_BUILD_COMMANDS="export BLIS_ARCH='generic'"
 PRE_BUILD_COMMANDS="export BLIS_ARCH='haswell'"
 #PRE_BUILD_COMMANDS="export BLIS_ARCH='skx'"

--- a/config/bx-python.sh
+++ b/config/bx-python.sh
@@ -1,2 +1,2 @@
-PYTHON_DEPS="numpy python-lzo six"
+PYTHON_DEPS="numpy~=$NUMPY_DEFAULT_VERSION python-lzo six"
 

--- a/config/cgat.sh
+++ b/config/cgat.sh
@@ -1,2 +1,2 @@
-PYTHON_DEPS="numpy cython pysam setuptools pyparsing pyaml alignlib-lite matplotlib biopython"
+PYTHON_DEPS="numpy~=$NUMPY_DEFAULT_VERSION cython pysam setuptools pyparsing pyaml alignlib-lite matplotlib biopython"
 

--- a/config/cupy.sh
+++ b/config/cupy.sh
@@ -1,5 +1,5 @@
 
-PYTHON_DEPS="numpy scipy optuna"
+PYTHON_DEPS="numpy~=$NUMPY_DEFAULT_VERSION scipy optuna"
 MODULE_BUILD_DEPS="gcc/9.3.0 cuda/11.4 cudnn nccl"
 # needed otherwise it does not find libcuda.so
 PRE_DOWNLOAD_COMMANDS='export LDFLAGS="-L$EBROOTCUDA/lib64/stubs -L$EBROOTNCCL/lib" ; export CFLAGS="-I$EBROOTNCCL/include/"'

--- a/config/cvxpy.sh
+++ b/config/cvxpy.sh
@@ -1,2 +1,2 @@
-PYTHON_DEPS="numpy multiprocess scs fastcache scipy six toolz CVXcanon dill"
+PYTHON_DEPS="numpy~=$NUMPY_DEFAULT_VERSION multiprocess scs fastcache scipy six toolz CVXcanon dill"
 

--- a/config/dadi.sh
+++ b/config/dadi.sh
@@ -1,4 +1,4 @@
 #MODULE_BUILD_DEPS='scipy-stack'
 MODULE_RUNTIME_DEPS='scipy-stack'
-#PYTHON_DEPS="six numpy scipy matplotlib ipython"
+#PYTHON_DEPS="six numpy~=$NUMPY_DEFAULT_VERSION scipy matplotlib ipython"
 #TEST_COMMAND="cd tests; python run_tests.py"

--- a/config/deepchem.sh
+++ b/config/deepchem.sh
@@ -1,3 +1,3 @@
-PYTHON_DEPS="numpy pandas joblib scikit-learn tensorflow_gpu pillow simdna"
+PYTHON_DEPS="numpy~=$NUMPY_DEFAULT_VERSION pandas joblib scikit-learn tensorflow_gpu pillow simdna"
 MODULE_RUNTIME_DEPS="gcc/5.4.0 rdkit/2018.03.3"
 

--- a/config/fast5_research.sh
+++ b/config/fast5_research.sh
@@ -1,2 +1,2 @@
-PYTHON_DEPS="numpy h5py"
+PYTHON_DEPS="numpy~=$NUMPY_DEFAULT_VERSION h5py"
 

--- a/config/freud-analysis.sh
+++ b/config/freud-analysis.sh
@@ -1,4 +1,4 @@
 # https://freud.readthedocs.io/en/stable/gettingstarted/installation.html#compile-from-source
 MODULE_BUILD_DEPS="tbb"
-PYTHON_DEPS="numpy cython scikit-build"
+PYTHON_DEPS="numpy~=$NUMPY_DEFAULT_VERSION cython scikit-build"
 PYTHON_IMPORT_NAME="freud"

--- a/config/fuel.sh
+++ b/config/fuel.sh
@@ -1,2 +1,2 @@
-PYTHON_DEPS="numpy six picklable_itertools pyyaml h5py tables progressbar2 pyzmq scipy pillow numexpr"
+PYTHON_DEPS="numpy~=$NUMPY_DEFAULT_VERSION six picklable_itertools pyyaml h5py tables progressbar2 pyzmq scipy pillow numexpr"
 

--- a/config/genomeview.sh
+++ b/config/genomeview.sh
@@ -1,1 +1,1 @@
-PYTHON_DEPS="numpy scipy cython pysam"
+PYTHON_DEPS="numpy~=$NUMPY_DEFAULT_VERSION scipy cython pysam"

--- a/config/gmso.sh
+++ b/config/gmso.sh
@@ -1,5 +1,5 @@
 PACKAGE_DOWNLOAD_ARGUMENT="https://github.com/mosdef-hub/gmso/archive/refs/tags/${VERSION}.tar.gz"
-PYTHON_DEPS="numpy sympy unyt boltons lxml pydantic<1.9.0 networkx ele"
+PYTHON_DEPS="numpy~=$NUMPY_DEFAULT_VERSION sympy unyt boltons lxml pydantic<1.9.0 networkx ele"
 PATCHES="gmso.patch"
 if [[ "$VERSION" == "0.7.3" ]]; then
   # they forgot to change this flag, causing .dev0 to be added to the version

--- a/config/h5py.sh
+++ b/config/h5py.sh
@@ -7,6 +7,6 @@ if [[ -z $EBROOTGENTOO ]]; then
 else
 	MODULE_BUILD_DEPS="gcc/9.3.0 hdf5"
 fi
-PYTHON_DEPS="nose numpy six Cython unittest2"
+PYTHON_DEPS="nose numpy~=$NUMPY_DEFAULT_VERSION six Cython unittest2"
 PYTHON_TESTS="h5py.run_tests()"
 

--- a/config/humann.sh
+++ b/config/humann.sh
@@ -1,4 +1,4 @@
-PYTHON_DEPS="numpy biopython biom_format matplotlib scipy MetaPhlAn"
+PYTHON_DEPS="numpy~=$NUMPY_DEFAULT_VERSION biopython biom_format matplotlib scipy MetaPhlAn"
 MODULE_BUILD_DEPS="gcc/7.3.0 bowtie2/2.3.5.1 scipy-stack/2019b diamond/0.9.32 glpk/4.65"
 PACKAGE_DOWNLOAD_ARGUMENT="https://files.pythonhosted.org/packages/9d/57/08aa836c56651f0a4e03f5883860a803bc4aabb2d1357df5f0d6f0841edf/humann-{VERSION}.tar.gz"
 PACKAGE_DOWNLOAD_NAME="humann-{VERSION}.tar.gz"

--- a/config/humann2.sh
+++ b/config/humann2.sh
@@ -1,4 +1,4 @@
-PYTHON_DEPS="numpy biopython biom_format matplotlib scipy MetaPhlAn"
+PYTHON_DEPS="numpy~=$NUMPY_DEFAULT_VERSION biopython biom_format matplotlib scipy MetaPhlAn"
 MODULE_BUILD_DEPS="gcc/7.3.0 bowtie2/2.3.5.1 scipy-stack/2019b diamond/0.9.32 glpk/4.65"
 PACKAGE_DOWNLOAD_ARGUMENT="https://files.pythonhosted.org/packages/58/e8/d64074e0c9e8d5cef5c3a430739831eb9930fc2c3647b6dbff70ccd5a953/humann2-{VERSION}.tar.gz"
 PACKAGE_DOWNLOAD_NAME="humann2-{VERSION}.tar.gz"

--- a/config/ipyrad.sh
+++ b/config/ipyrad.sh
@@ -1,4 +1,4 @@
-PYTHON_DEPS="numpy scipy pandas numba ipyparallel pysam cutadapt requests h5py"
+PYTHON_DEPS="numpy~=$NUMPY_DEFAULT_VERSION scipy pandas numba ipyparallel pysam cutadapt requests h5py"
 MODULE_RUNTIME_DEPS="muscle samtools bedtools vsearch bwa"
 PACKAGE_DOWNLOAD_ARGUMENT="https://github.com/dereneaton/ipyrad/archive/$VERSION.tar.gz"
 PACKAGE_DOWNLOAD_NAME="$VERSION.tar.gz"

--- a/config/jcvi.sh
+++ b/config/jcvi.sh
@@ -1,2 +1,2 @@
-PYTHON_DEPS="biopython numpy deap networkx matplotlib cython"
+PYTHON_DEPS="biopython numpy~=$NUMPY_DEFAULT_VERSION deap networkx matplotlib cython"
 

--- a/config/justblast.sh
+++ b/config/justblast.sh
@@ -1,5 +1,5 @@
 PACKAGE="justblast"
-PYTHON_DEPS="numpy scipy distributed dask dill tqdm psutils"
+PYTHON_DEPS="numpy~=$NUMPY_DEFAULT_VERSION scipy distributed dask dill tqdm psutils"
 PYTHON_IMPORT_NAME=$PACKAGE
 PACKAGE_FOLDER_NAME=$PACKAGE
 PACKAGE_DOWNLOAD_ARGUMENT="https://github.com/jshleap/justblast/archive/2020.0.4.tar.gz"

--- a/config/matplotlib.sh
+++ b/config/matplotlib.sh
@@ -1,2 +1,2 @@
-PYTHON_DEPS="pyparsing pytz six cycler python-dateutil numpy backports.functools-lru-cache kiwisolver"
+PYTHON_DEPS="pyparsing pytz six cycler python-dateutil numpy~=$NUMPY_DEFAULT_VERSION backports.functools-lru-cache kiwisolver"
 

--- a/config/mdtraj.sh
+++ b/config/mdtraj.sh
@@ -1,2 +1,2 @@
-PYTHON_DEPS="cython numpy scipy pandas"
+PYTHON_DEPS="cython numpy~=$NUMPY_DEFAULT_VERSION scipy pandas"
 

--- a/config/mikado.sh
+++ b/config/mikado.sh
@@ -1,3 +1,3 @@
 MODULE_BUILD_DEPS="scipy-stack/2020b"
-PYTHON_DEPS="nose numpy six Cython unittest2 scipy sympy biopython==1.76"
+PYTHON_DEPS="nose numpy~=$NUMPY_DEFAULT_VERSION six Cython unittest2 scipy sympy biopython==1.76"
 PYTHON_IMPORT_NAME="Mikado"

--- a/config/mkl.sh
+++ b/config/mkl.sh
@@ -1,4 +1,4 @@
 MODULE_BUILD_DEPS="imkl/2020.1.217"
-PYTHON_DEPS="nose numpy pytest scipy"
+PYTHON_DEPS="nose numpy~=$NUMPY_DEFAULT_VERSION pytest scipy"
 
 

--- a/config/mpi4py-fft.sh
+++ b/config/mpi4py-fft.sh
@@ -1,5 +1,5 @@
 MODULE_BUILD_DEPS="gcc/9.3.0 openmpi/4.0.3 fftw-mpi/3.3.8 scipy-stack/2020b hdf5-mpi/1.10.6"
-PYTHON_DEPS="nose numpy six Cython unittest2 scipy sympy"
+PYTHON_DEPS="nose numpy~=$NUMPY_DEFAULT_VERSION six Cython unittest2 scipy sympy"
 PRE_DOWNLOAD_COMMANDS="export FFTW_LIBRARY_DIR=$EBROOTFFTW/lib"
 PYTHON_IMPORT_NAME="mpi4py_fft"
 PYTHON_TESTS="from mpi4py_fft import DistArray; from mpi4py_fft.pencil import Pencil, Subcomm"

--- a/config/msmbuilder.sh
+++ b/config/msmbuilder.sh
@@ -1,2 +1,2 @@
-PYTHON_DEPS="numpy scipy scikit-learn mdtraj pandas cython<0.28 cvxopt nose"
+PYTHON_DEPS="numpy~=$NUMPY_DEFAULT_VERSION scipy scikit-learn mdtraj pandas cython<0.28 cvxopt nose"
 

--- a/config/numba-0.31.0.sh
+++ b/config/numba-0.31.0.sh
@@ -1,2 +1,2 @@
-PYTHON_DEPS="numpy enum34 llvmlite==0.16.0"
+PYTHON_DEPS="numpy~=$NUMPY_DEFAULT_VERSION enum34 llvmlite==0.16.0"
 

--- a/config/numba.sh
+++ b/config/numba.sh
@@ -1,2 +1,2 @@
-PYTHON_DEPS="numpy enum34 llvmlite"
+PYTHON_DEPS="numpy~=$NUMPY_DEFAULT_VERSION enum34 llvmlite"
 MODULE_RUNTIME_DEPS="llvm"

--- a/config/pandas.sh
+++ b/config/pandas.sh
@@ -1,2 +1,2 @@
-PYTHON_DEPS="numpy python-dateutil pytz Cython numexpr bottleneck scipy tables matplotlib nose pytest moto"
+PYTHON_DEPS="numpy~=$NUMPY_DEFAULT_VERSION python-dateutil pytz Cython numexpr bottleneck scipy tables matplotlib nose pytest moto"
 

--- a/config/phyluce.sh
+++ b/config/phyluce.sh
@@ -1,5 +1,5 @@
 
-#PYTHON_DEPS="numpy dipy scipy nibabel h5py six"
+#PYTHON_DEPS="numpy~=$NUMPY_DEFAULT_VERSION dipy scipy nibabel h5py six"
 PACKAGE_DOWNLOAD_ARGUMENT="https://github.com/faircloth-lab/phyluce/archive/v${VERSION}.tar.gz"
 PACKAGE_DOWNLOAD_NAME="${VERSION}.tar.gz"
 #PACKAGE_FOLDER_NAME="AMICO-master"

--- a/config/psfex.sh
+++ b/config/psfex.sh
@@ -2,5 +2,5 @@ PACKAGE_DOWNLOAD_ARGUMENT="https://github.com/esheldon/psfex/archive/v${VERSION}
 PACKAGE_DOWNLOAD_NAME="v${VERSION}.tar.gz"
 PACKAGE_FOLDER_NAME="psfex-${VERSION}"
 #MODULE_BUILD_DEPS=""
-PYTHON_DEPS="numpy fitsio"
+PYTHON_DEPS="numpy~=$NUMPY_DEFAULT_VERSION fitsio"
 

--- a/config/pyscenic.sh
+++ b/config/pyscenic.sh
@@ -1,4 +1,4 @@
 MODULE_RUNTIME_DEPS="nixpkgs/16.09  gcc/8.3.0  cuda/10.1 arrow/0.16.0"
-PYTHON_DEPS="cytoolz multiprocessing_on_dill llvmlite numba attrs frozendict numpy 'pandas>=0.20.1,<1.0.0' cloudpickle 'dask==1.0.0' 'distributed>=1.21.6,<2.0.0' 'pyarrow>=0.11.1,<0.17.0' arboreto boltons setuptools pyyaml tqdm interlap umap-learn loompy networkx scipy"
+PYTHON_DEPS="cytoolz multiprocessing_on_dill llvmlite numba attrs frozendict numpy~=$NUMPY_DEFAULT_VERSION 'pandas>=0.20.1,<1.0.0' cloudpickle 'dask==1.0.0' 'distributed>=1.21.6,<2.0.0' 'pyarrow>=0.11.1,<0.17.0' arboreto boltons setuptools pyyaml tqdm interlap umap-learn loompy networkx scipy"
 PYTHON_DEPS_DEFAULT=""
 PYTHON_TESTS=""

--- a/config/qiime.sh
+++ b/config/qiime.sh
@@ -1,2 +1,2 @@
-PYTHON_DEPS="numpy scipy matplotlib mock nose cycler decorator enum34 functools32 ipython matplotlib pexpect emperor qcli natsort<4.0.0"
+PYTHON_DEPS="numpy~=$NUMPY_DEFAULT_VERSION scipy matplotlib mock nose cycler decorator enum34 functools32 ipython matplotlib pexpect emperor qcli natsort<4.0.0"
 

--- a/config/qutip.sh
+++ b/config/qutip.sh
@@ -1,2 +1,2 @@
-PYTHON_DEPS="Cython numpy scipy matplotlib"
+PYTHON_DEPS="Cython numpy~=$NUMPY_DEFAULT_VERSION scipy matplotlib"
 

--- a/config/rasterio.sh
+++ b/config/rasterio.sh
@@ -1,2 +1,2 @@
-PYTHON_DEPS="numpy affine snuggs cligj click-plugins enum34"
+PYTHON_DEPS="numpy~=$NUMPY_DEFAULT_VERSION affine snuggs cligj click-plugins enum34"
 MODULE_BUILD_DEPS="gcc/9.3.0 gdal/3.2.3"

--- a/config/ray-0.7.0.sh
+++ b/config/ray-0.7.0.sh
@@ -1,6 +1,6 @@
 PACKAGE_DOWNLOAD_ARGUMENT="https://github.com/ray-project/ray/archive/ray-$VERSION.tar.gz"
 MODULE_BUILD_DEPS="gcc/7.3.0 bazel/0.19.2 qt/5.10.1"
-PYTHON_DEPS="numpy scipy cython"
+PYTHON_DEPS="numpy~=$NUMPY_DEFAULT_VERSION scipy cython"
 PACKAGE_FOLDER_NAME="ray-ray-*/python"
 PRE_BUILD_COMMANDS="pwd; sed -i -e 's/-DPARQUET_BUILD_TESTS=off/-DPARQUET_BUILD_TESTS=off -DCMAKE_SKIP_RPATH=ON -DCMAKE_SKIP_INSTALL_RPATH=ON/g' ../thirdparty/scripts/build_parquet.sh && sed -i -e 's/-DARROW_WITH_ZSTD=off/-DARROW_WITH_ZSTD=off  -DCMAKE_SKIP_RPATH=ON -DCMAKE_SKIP_INSTALL_RPATH=ON/g' ../thirdparty/scripts/build_arrow.sh"
 

--- a/config/ray.sh
+++ b/config/ray.sh
@@ -3,7 +3,7 @@ if [[ -z "$VERSION" ]]; then
 fi
 #PACKAGE_DOWNLOAD_ARGUMENT="https://github.com/ray-project/ray/archive/ray-$VERSION.tar.gz"
 MODULE_BUILD_DEPS="qt/5.12.8"
-PYTHON_DEPS="numpy scipy cython"
+PYTHON_DEPS="numpy~=$NUMPY_DEFAULT_VERSION scipy cython"
 #PACKAGE_FOLDER_NAME="ray-ray-*/python"
 #PRE_BUILD_COMMANDS="pwd; sed -i -e 's/-DPARQUET_BUILD_TESTS=off/-DPARQUET_BUILD_TESTS=off -DCMAKE_SKIP_RPATH=ON -DCMAKE_SKIP_INSTALL_RPATH=ON/g' ../thirdparty/scripts/build_parquet.sh && sed -i -e 's/-DARROW_WITH_ZSTD=off/-DARROW_WITH_ZSTD=off  -DCMAKE_SKIP_RPATH=ON -DCMAKE_SKIP_INSTALL_RPATH=ON/g' ../thirdparty/scripts/build_arrow.sh"
 

--- a/config/scikit-bio.sh
+++ b/config/scikit-bio.sh
@@ -1,2 +1,2 @@
-PYTHON_DEPS="numpy natsort"
+PYTHON_DEPS="numpy~=$NUMPY_DEFAULT_VERSION natsort"
 

--- a/config/scikit-multilearn.sh
+++ b/config/scikit-multilearn.sh
@@ -1,2 +1,2 @@
-PYTHON_DEPS="numpy scipy Cython scikit-learn liac-arff requests networkx python-louvain"
+PYTHON_DEPS="numpy~=$NUMPY_DEFAULT_VERSION scipy Cython scikit-learn liac-arff requests networkx python-louvain"
 

--- a/config/scipy.sh
+++ b/config/scipy.sh
@@ -1,4 +1,4 @@
 MODULE_BUILD_DEPS="arch/sse3 flexiblas/3.0.4"
 PYTHON_DEPS_DEFAULT=""
-PYTHON_DEPS="numpy pytest pybind11 cython pythran"
+PYTHON_DEPS="numpy~=$NUMPY_DEFAULT_VERSION pytest pybind11 cython pythran"
 PYTHON_TESTS="scipy.__config__.show(); scipy.test()"

--- a/config/seaborn.sh
+++ b/config/seaborn.sh
@@ -1,2 +1,2 @@
-PYTHON_DEPS="numpy scipy matplotlib pandas"
+PYTHON_DEPS="numpy~=$NUMPY_DEFAULT_VERSION scipy matplotlib pandas"
 

--- a/config/shenfun.sh
+++ b/config/shenfun.sh
@@ -1,3 +1,3 @@
 MODULE_BUILD_DEPS="gcc/9.3.0 openmpi/4.0.3 fftw-mpi/3.3.8 scipy-stack/2020b hdf5-mpi/1.10.6"
-PYTHON_DEPS="nose numpy six Cython unittest2 scipy sympy mpi4py-fft"
+PYTHON_DEPS="nose numpy~=$NUMPY_DEFAULT_VERSION six Cython unittest2 scipy sympy mpi4py-fft"
 PRE_DOWNLOAD_COMMANDS="export FFTW_LIBRARY_DIR=$EBROOTFFTW/lib"

--- a/config/skggm.sh
+++ b/config/skggm.sh
@@ -1,2 +1,2 @@
 MODULE_RUNTIME_DEPS='gcc/9.3.0'
-PYTHON_DEPS_DEFAULT="numpy scipy cython sklearn"
+PYTHON_DEPS_DEFAULT="numpy~=$NUMPY_DEFAULT_VERSION scipy cython sklearn"

--- a/config/sonicparanoid.sh
+++ b/config/sonicparanoid.sh
@@ -1,1 +1,1 @@
-PYTHON_DEPS="cython sh numpy pandas>=0.24 biopython scipy scikit-learn mypy psutil"
+PYTHON_DEPS="cython sh numpy~=$NUMPY_DEFAULT_VERSION pandas>=0.24 biopython scipy scikit-learn mypy psutil"

--- a/config/spectralDNS.sh
+++ b/config/spectralDNS.sh
@@ -1,4 +1,4 @@
 MODULE_BUILD_DEPS="gcc/9.3.0 openmpi/4.0.3 fftw-mpi/3.3.8 scipy-stack/2020b hdf5-mpi/1.10.6"
-PYTHON_DEPS="nose numpy six Cython unittest2 scipy sympy mpi4py-fft shenfun"
+PYTHON_DEPS="nose numpy~=$NUMPY_DEFAULT_VERSION six Cython unittest2 scipy sympy mpi4py-fft shenfun"
 PRE_DOWNLOAD_COMMANDS="export FFTW_LIBRARY_DIR=$EBROOTFFTW/lib"
 PACKAGE_DOWNLOAD_CMD="wget https://github.com/spectralDNS/spectralDNS/archive/1.2.0.tar.gz -O spectralDNS.tar.gz"

--- a/config/tables.sh
+++ b/config/tables.sh
@@ -1,4 +1,4 @@
 MODULE_BUILD_DEPS="gcc hdf5"
-PYTHON_DEPS="h5py numpy numexpr six nose mock"
+PYTHON_DEPS="h5py numpy~=$NUMPY_DEFAULT_VERSION numexpr six nose mock"
 PYTHON_TESTS="tables.test()"
 

--- a/config/tetrad.sh
+++ b/config/tetrad.sh
@@ -1,4 +1,4 @@
-PYTHON_DEPS="numpy scipy pandas numba ipyparallel pysam cutadapt requests h5py ipyrad"
+PYTHON_DEPS="numpy~=$NUMPY_DEFAULT_VERSION scipy pandas numba ipyparallel pysam cutadapt requests h5py ipyrad"
 MODULE_RUNTIME_DEPS="muscle samtools bedtools vsearch bwa"
 PACKAGE_DOWNLOAD_ARGUMENT="https://github.com/eaton-lab/tetrad/archive/$VERSION.tar.gz"
 PACKAGE_DOWNLOAD_NAME="$VERSION.tar.gz"

--- a/config/torchsummary.sh
+++ b/config/torchsummary.sh
@@ -1,4 +1,4 @@
-PYTHON_DEPS="numpy six pillow-simd torch torch.nn"
+PYTHON_DEPS="numpy~=$NUMPY_DEFAULT_VERSION six pillow-simd torch torch.nn"
 PACKAGE_DOWNLOAD_ARGUMENT="https://files.pythonhosted.org/packages/5b/64/aa68ef646bcccab489cac2a85d366559df7d9d24406dbbf3344703cbe33f/torchsummary-{VERSION}tar.gz"
 PYTHON_VERSIONS="python/3.6 python/3.7 python/3.8"
 MODULE_BUILD_DEPS=scipy-stack/2019b

--- a/config/velocyto.sh
+++ b/config/velocyto.sh
@@ -1,3 +1,3 @@
-PYTHON_DEPS="numpy scipy cython numba matplotlib scikit-learn h5py loompy pysam Click pandas"
+PYTHON_DEPS="numpy~=$NUMPY_DEFAULT_VERSION scipy cython numba matplotlib scikit-learn h5py loompy pysam Click pandas"
 PYTHON_VERSIONS="python/3.6 python/3.7"
 

--- a/manipulate_wheels.py
+++ b/manipulate_wheels.py
@@ -69,8 +69,8 @@ def main():
                     continue
 
                 wf2 = None
+                version = str(wf.version)
                 if args.insert_local_version:
-                    version = str(wf.version)
                     if LOCAL_VERSION in version:
                         if args.verbose:
                             print("wheel %s already has the %s local version. Skipping" % (w, LOCAL_VERSION))
@@ -85,7 +85,8 @@ def main():
 
                 if args.update_req:
                     if not wf2:
-                        wf2 = WheelFile.from_wheelfile(wf, file_or_path=TMP_DIR)
+                        wf2 = WheelFile.from_wheelfile(
+                            wf, file_or_path=TMP_DIR, version=version)
                     for req in args.update_req:
                         # If an update does rename a requirement, split from and to, else ignore
                         from_req, to_req = req.split(RENAME_SEP) if RENAME_SEP in req else (req, req)

--- a/unmanylinuxize.sh
+++ b/unmanylinuxize.sh
@@ -5,7 +5,7 @@ SCRIPT_DIR=$(dirname -- "$(readlink -f -- "$THIS_SCRIPT")")
 
 function ls_pythons()
 {
-	ls -1d /cvmfs/soft.computecanada.ca/easybuild/software/20*/Core/python/3* /cvmfs/soft.computecanada.ca/easybuild/software/2020/avx*/Core/python/3* | grep -v "3.[56]" | grep -Po "\d\.\d" | sort -u | tr '\n' ','
+	ls -1d /cvmfs/soft.computecanada.ca/easybuild/software/20*/Core/python/3* /cvmfs/soft.computecanada.ca/easybuild/software/2020/avx*/Core/python/3* | grep -v "3.[567]" | grep -Po "\d\.\d+" | sort -u | tr '\n' ','
 }
 
 function print_usage


### PR DESCRIPTION
This pull requests does a few things: 
* it pins the default version of numpy to a specific version
* it detects if a wheel contains shared objects that link on a specific version of `numpy`. If it is the case, it uses `manipulate_wheels` to update the requirements for numpy and set a minimum version corresponding to the version with which we built. 