### PR TITLE
Updated Numpy config to let distutils.system_config know about blas. …

### DIFF
--- a/config/numpy.sh
+++ b/config/numpy.sh
@@ -1,6 +1,17 @@
-PRE_BUILD_COMMANDS='module load flexiblas/3.0.4; echo "[DEFAULT]" > site.cfg; echo "library_dirs = $EBROOTFLEXIBLAS/lib" >> site.cfg; echo "include_dirs = $EBROOTFLEXIBLAS/include/flexiblas" >> site.cfg; echo "[atlas]" >> site.cfg; echo "atlas_libs = flexiblas" >> site.cfg; echo "[lapack]" >> site.cfg; echo "lapack_libs = flexiblas" >> site.cfg'
+# One could also set NPY_BLAS_LIBS, NPY_LAPACK_LIBS and NPY_CBLAS_LIBS since numpy 1.21.
+PRE_BUILD_COMMANDS='module load flexiblas/3.0.4;
+echo "[DEFAULT]" > site.cfg;
+echo "library_dirs = $EBROOTFLEXIBLAS/lib" >> site.cfg;
+echo "include_dirs = $EBROOTFLEXIBLAS/include/flexiblas" >> site.cfg;
+echo "[atlas]" >> site.cfg;
+echo "libraries = flexiblas" >> site.cfg;
+echo "[blis]" >> site.cfg;
+echo "libraries = flexiblas" >> site.cfg;
+echo "[lapack]" >> site.cfg;
+echo "libraries = flexiblas" >> site.cfg;
+echo "[blas]" >> site.cfg;
+echo "libraries = flexiblas" >> site.cfg;'
 MODULE_BUILD_DEPS="arch/sse3 flexiblas/3.0.4"
 PYTHON_DEPS="nose pytest cython hypothesis py==1.10.0 importlib_metadata==4.8.1 typing_extensions==4.0.0"
 PYTHON_DEPS_DEFAULT=""
 PYTHON_TESTS="numpy.__config__.show(); numpy.test()"
-


### PR DESCRIPTION
…Updated site.cfg to use libraries as does upstream.
Also added `blis` libraries.

Some packages relies on `numpy.distutils` to find `blas` and `lapack` libraries. Even though `numpy.distutils` is deprecated in numpy 1.23 and will be removed : https://numpy.org/devdocs/reference/distutils_status_migration.html

This allows one to:
```python
>>> import numpy.distutils.system_info as sysinfo
>>> sysinfo.get_info('blas')
{'libraries': ['flexiblas', 'flexiblas'], 'library_dirs': ['/cvmfs/soft.computecanada.ca/easybuild/software/2020/Core/flexiblas/3.0.4/lib'], 'include_dirs': ['/cvmfs/soft.computecanada.ca/easybuild/software/2020/Core/flexiblas/3.0.4/include/flexiblas'], 'language': 'c', 'define_macros': [('HAVE_CBLAS', None)]}
>>> sysinfo.get_info('lapack')
{'libraries': ['flexiblas', 'flexiblas'], 'library_dirs': ['/cvmfs/soft.computecanada.ca/easybuild/software/2020/Core/flexiblas/3.0.4/lib'], 'language': 'f77'}
>>> sysinfo.get_info('blis')
{'libraries': ['flexiblas', 'flexiblas'], 'library_dirs': ['/cvmfs/soft.computecanada.ca/easybuild/software/2020/avx2/Compiler/intel2020/flexiblas/3.0.4/lib'], 'define_macros': [('HAVE_CBLAS', None)], 'include_dirs': ['/cvmfs/soft.computecanada.ca/easybuild/software/2020/avx2/Compiler/intel2020/flexiblas/3.0.4/include/flexiblas'], 'language': 'c'}
```

Versus currently:
```python
>>> import numpy.distutils.system_info as sysinfo
>>> sysinfo.get_info('lapack')
{'libraries': ['flexiblas'], 'library_dirs': ['/cvmfs/soft.computecanada.ca/easybuild/software/2020/Core/flexiblas/3.0.4/lib'], 'language': 'f77'}
>>> sysinfo.get_info('blas')
{}
>>> sysinfo.get_info('blis')
{}
```
