### PR TITLE
Add xprec config file

### DIFF
--- a/config/xprec.sh
+++ b/config/xprec.sh
@@ -1,0 +1,1 @@
+PRE_BUILD_COMMANDS="export LDSHARED=\"gcc --shared -Wl,-Bsymbolic-functions\""

--- a/packages_w_numpy_api.txt
+++ b/packages_w_numpy_api.txt
@@ -23,3 +23,4 @@ pyhdf
 pybullet-svl
 pybullet_svl
 vaex-core
+xprec


### PR DESCRIPTION
Adjust the linker options at compile step or many of xprec automated tests would fail.