### PR TITLE
Updated default python to build for. Sort version ascendingly

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Usage: build_wheel.sh --package <python package name>
     --recursive       Recursively build wheels for dependencies.
     --package         Name of the Python package to build.
     --version         Version of the Python package to build. (default:  latest)
-    --python          Build wheels for these Python versions. (default: "3.8,3.9,3.10,3.11")
+    --python          Build wheels for these Python versions. (default: "3.9,3.10,3.11")
     --keep-build-dir  Don't delete build-dirs after successful build.
     --autocopy        Run `./cp_wheels.sh --remove` after successful build.
     --verbose         Set level for verbosity. (0,1,2,3; default: 0)
@@ -47,7 +47,7 @@ This script will:
 - Add the +computecanada to the wheel name.
 - To test: install the wheel into the build-virtualenv and try to import it.
 
-By default, it tries to build wheels for Python 3.8, 3.9, 3.10, and 3.11.
+By default, it tries to build wheels for Python 3.9, 3.10, and 3.11.
 
 If no `arch` module is loaded, it will load `arch/sse3`, our current smallest
 common denominator. To build AVX2-optimised wheels, do `module load arch/avx2`

--- a/build_wheel.sh
+++ b/build_wheel.sh
@@ -4,7 +4,7 @@ THIS_SCRIPT=$0
 SCRIPT_DIR=$(dirname -- "$(readlink -f -- "$THIS_SCRIPT")")
 
 if [[ -z "$PYTHON_VERSIONS" ]]; then
-	PYTHON_VERSIONS=$(module --terse spider python | grep -v "/2\.\|/3.[567]" | grep -Po "\d\.\d+" | sort -u | sed 's#^#python/#')
+	PYTHON_VERSIONS=$(module --terse spider python | grep -v "/2\.\|/3.[5678]" | grep -Po "\d\.\d+" | sort -Vu | sed 's#^#python/#')
 fi
 
 function print_usage {

--- a/parbuild_wheel.sh
+++ b/parbuild_wheel.sh
@@ -5,7 +5,7 @@
 
 function ls_pythons()
 {
-	ls -1d /cvmfs/soft.computecanada.ca/easybuild/software/20*/Core/python/3* /cvmfs/soft.computecanada.ca/easybuild/software/2020/avx*/Core/python/3* | grep -v "3.[567]" | grep -Po "\d\.\d+" | sort -u | tr '\n' ','
+	ls -1d /cvmfs/soft.computecanada.ca/easybuild/software/20*/Core/python/3* /cvmfs/soft.computecanada.ca/easybuild/software/2020/avx*/Core/python/3* | grep -v "3.[5678]" | grep -Po "\d\.\d+" | sort -Vu | tr '\n' ','
 }
 
 function print_usage

--- a/unmanylinuxize.sh
+++ b/unmanylinuxize.sh
@@ -5,7 +5,7 @@ SCRIPT_DIR=$(dirname -- "$(readlink -f -- "$THIS_SCRIPT")")
 
 function ls_pythons()
 {
-	ls -1d /cvmfs/soft.computecanada.ca/easybuild/software/20*/Core/python/3* /cvmfs/soft.computecanada.ca/easybuild/software/2020/avx*/Core/python/3* | grep -v "3.[567]" | grep -Po "\d\.\d+" | sort -u | tr '\n' ','
+	ls -1d /cvmfs/soft.computecanada.ca/easybuild/software/20*/Core/python/3* /cvmfs/soft.computecanada.ca/easybuild/software/2020/avx*/Core/python/3* | grep -v "3.[5678]" | grep -Po "\d\.\d+" | sort -Vu | tr '\n' ','
 }
 
 function print_usage


### PR DESCRIPTION
Exclude Python 3.8 now that Python 3.10 is the default.
Sort versions in ascending order.