### PR TITLE
Use gentoo2020/2023 for SIGILL-causing wheels

### DIFF
--- a/cp_wheels.sh
+++ b/cp_wheels.sh
@@ -72,7 +72,7 @@ function cp_wheel {
 		# layer but can still be arch-specific if they make use of SIMD
 		# instructions. In that case, we put them in gentoo since new
 		# wheels might be incompatible with the older glibc in Nix.
-		COMPAT=gentoo
+		COMPAT=gentoo$EBVERSIONGENTOO
 	fi
 	echo chmod ug+rw,o+r $1
 	if [[ "$ARG_DRY_RUN" == "" ]]; then


### PR DESCRIPTION
I think we also need that here, for debugpy.