### PR TITLE
wheel_architecture adjustments for 2023

### DIFF
--- a/wheel_architecture.sh
+++ b/wheel_architecture.sh
@@ -74,7 +74,7 @@ for fname in $(find . -type f); do
 		WORKS_ON_NIX=0
 		WORKS_ON_GENTOO2023=0
 		echo "$fname" is gentoo2020, rpath=$rpath  >&2
-	elif [[ $rpath =~ 'gentoo/2023' || $rpath =~ 'easybuild/software/2023' ]]; then
+	elif [[ $rpath =~ 'gentoo/2023' || $rpath =~ 'easybuild/software/2023' || "$EBVERSIONGENTOO" == "2023" ]]; then
 		WORKS_ON_NIX=0
 		WORKS_ON_GENTOO2020=0
 		echo "$fname" is gentoo2023, rpath=$rpath  >&2

--- a/wheel_architecture.sh
+++ b/wheel_architecture.sh
@@ -139,7 +139,7 @@ for fname in $(find . -type f); do
 	elif [[ $rpath =~ '/avx512/' ]]; then
 		ARCHITECTURE="avx512"
 		echo "$fname" is $COMPATIBILITY_LAYER $ARCHITECTURE, rpath=$rpath  >&2
-	elif [[ $rpath =~ '/x86-64-v3/' && ! $rpath =~ '/x86-64-v3/Core/' ]]; then
+	elif [[ $rpath =~ '/x86-64-v3/' ]]; then
 		ARCHITECTURE="x86-64-v3"
 		echo "$fname" is $COMPATIBILITY_LAYER $ARCHITECTURE, rpath=$rpath  >&2
 	elif [[ $rpath =~ '/x86-64-v4/' ]]; then


### PR DESCRIPTION
* Move all wheels with 2023 easybuild rpaths to arch dir
* Under StdEnv/2023 make all wheels with C extensions `gentoo2023` as they can't be shared as purely generic with older StdEnv: they are highly likely to contain illegal instructions for CPUs without AVX2 or BMI2.