### PR TITLE
add code to set the lower-than version of numpy required

### DIFF
--- a/manipulate_wheels.py
+++ b/manipulate_wheels.py
@@ -180,8 +180,11 @@ def main():
                             numpy_req_found = True
                             if args.verbose:
                                 print('Found numpy dependency.')
-                            curr_version_req = curr_req.replace("numpy","").replace("(","").replace(")","").strip()
+                            curr_version_req = curr_req.split(';')[0].replace("numpy","").replace("(","").replace(")","").strip()
                             req_tokens = ["numpy",""]
+                            if len(curr_req.split(';')) == 2:
+                                req_tokens += [';' + curr_req.split(';')[1]]
+
                             min_numpy_set = False
                             lt_numpy_set = False
                             req_versions = []

--- a/manipulate_wheels.py
+++ b/manipulate_wheels.py
@@ -219,7 +219,7 @@ def main():
                                 version_specifiers += ['<'+args.set_lt_numpy]
                             to_req_tokens[1] = '(' + ','.join(version_specifiers) + ')'
 
-                            to_req = ' '.join(new_req_tokens)
+                            to_req = ' '.join(to_req_tokens)
                             if curr_req != to_req:
                                 if args.verbose:
                                     print(f"{w}: updating requirement {curr_req} to {to_req}")


### PR DESCRIPTION
I would like to get more eyes on this code, make sure I have not forgotten some cases.. 

Here is what it gives for the `tf_models_official` wheel: 

```
$ ./manipulate_wheels.py --print_req --wheel tf_models_official-2.15.0+computecanada-py2.py3-none-any.whl | grep numpy
numpy >=1.20

$ ./manipulate_wheels.py --set_lt_numpy 2.0 --inplace --force --wheel tf_models_official-2.15.0+computecanada-py2.py3-none-any.whl
Since --force was used, overwriting existing wheel
New wheel created tf_models_official-2.15.0+computecanada-py2.py3-none-any.whl

$ ./manipulate_wheels.py --print_req --wheel tf_models_official-2.15.0+computecanada-py2.py3-none-any.whl | grep numpy
numpy (>=1.20,<2.0)
``` 