### PR TITLE
Source config file case-insensitively

### DIFF
--- a/build_wheel.sh
+++ b/build_wheel.sh
@@ -118,12 +118,19 @@ else
 fi
 
 CONFIGDIR=$SCRIPT_DIR/config
-if [[ -e "$CONFIGDIR/${PACKAGE}-${VERSION}.sh" ]]; then
-	source $CONFIGDIR/${PACKAGE}-${VERSION}.sh
-	echo "INFO: Sourced configuration $CONFIGDIR/${PACKAGE}-${VERSION}.sh"
-elif [[ -e "$CONFIGDIR/${PACKAGE}.sh" ]]; then
-	source $CONFIGDIR/${PACKAGE}.sh
-	echo "INFO: Sourced configuration $CONFIGDIR/${PACKAGE}.sh"
+PACKAGE_PATTERN=$(echo $PACKAGE | sed -e 's/[_-]/\?/') # Ignores packages with - or _ replace with ? char for pattern.
+# Check case-insensitively if package-version.sh exists.
+if [[ -n $(find $CONFIGDIR -iname "${PACKAGE_PATTERN}-${VERSION}.sh") ]]; then
+	config_name=$(find $CONFIGDIR -iname "${PACKAGE_PATTERN}-${VERSION}.sh")
+	echo "INFO: Sourced configuration $config_name"
+	source $config_name
+
+# Check case-insensitively if package.sh exists.
+elif [[ -n $(find $CONFIGDIR -iname "${PACKAGE_PATTERN}.sh") ]]; then
+	config_name=$(find $CONFIGDIR -iname "${PACKAGE_PATTERN}.sh")
+	echo "INFO: Sourced configuration $config_name"
+	source $config_name
+
 else
 	echo "INFO: no configuration file sourced."
 fi


### PR DESCRIPTION
Allow for less mistakes, easier builds.

Normalized config names when sourced, by ignoring case and `-` or `_`.

- if `pennylane` requires `PennyLane_Lightning`, then the existing config `pennylane-lightning` is used.
- if `torch-scatter` and version `2.0.3` is specified, then the existing config is used, if the version does not exists, than the default of `torch_scatter` is used
- if no config exists, then no config is used.