### PR TITLE
Python 3.13

### DIFF
--- a/build_wheel.sh
+++ b/build_wheel.sh
@@ -13,7 +13,7 @@ elif [[ "$YEAR" == "2020" ]]; then
 	NUMPY_MODULE="oldest-supported-numpy/.2022a"
 else
 	GCC_VERSION=12.3
-	EXCLUDE_PYTHON_VERSIONS="/2\.\|/3.[56789]"
+	EXCLUDE_PYTHON_VERSIONS="/2\.\|/3.[56789]\|3.10"
 	CYTHON_VERSION=.3.0.10
 	NUMPY_MODULE="numpy/.2.1.1" # oldest-supported-numpy is now depcrecated with v2.0+
 fi

--- a/build_wheel.sh
+++ b/build_wheel.sh
@@ -14,7 +14,7 @@ elif [[ "$YEAR" == "2020" ]]; then
 else
 	GCC_VERSION=12.3
 	EXCLUDE_PYTHON_VERSIONS="/2\.\|/3.[56789]\|3.10"
-	CYTHON_VERSION=.3.0.10
+	CYTHON_VERSION=.3.0.11
 	NUMPY_MODULE="numpy/.2.1.1" # oldest-supported-numpy is now depcrecated with v2.0+
 fi
 

--- a/config/numpy.sh
+++ b/config/numpy.sh
@@ -16,6 +16,6 @@ PIP_WHEEL_ARGS='
 '
 # cython is not picked up in one test, and it fail. Install cython in the virtual env.
 PRE_TEST_COMMANDS="pip install --ignore-installed 'cython>3.0.0'"
-MODULE_BUILD_DEPS_DEFAULT="cython/.3.0.10"
+MODULE_BUILD_DEPS_DEFAULT="cython/.3.0.11"
 
 PYTHON_TESTS="numpy.__config__.show(); numpy.test()"

--- a/config/quast.sh
+++ b/config/quast.sh
@@ -1,2 +1,3 @@
 MODULE_RUNTIME_DEPS="gcc rust java boost perl"
 PYTHON_DEPS="simplejson setuptools-rust joblib path matplotlib"
+PACKAGE_DOWNLOAD_URL="https://github.com/ablab/quast/releases/download/quast_$VERSION/quast-${VERSION:?version required}.tar.gz"

--- a/parbuild_wheel.sh
+++ b/parbuild_wheel.sh
@@ -7,7 +7,7 @@
 YEAR="${EBVERSIONGENTOO:-2017}"
 EXCLUDE_PYTHON_VERSIONS="/2\.\|/3.[5678]"
 if [[ "$YEAR" == "2023" ]]; then
-	EXCLUDE_PYTHON_VERSIONS="/2\.\|/3.[56789]"
+	EXCLUDE_PYTHON_VERSIONS="/2\.\|/3.[56789]\|3.10"
 fi
 
 function ls_pythons()

--- a/unmanylinuxize.sh
+++ b/unmanylinuxize.sh
@@ -4,7 +4,7 @@ THIS_SCRIPT=$0
 SCRIPT_DIR=$(dirname -- "$(readlink -f -- "$THIS_SCRIPT")")
 EXCLUDE_PYTHON_VERSIONS="/2\.\|/3.[5678]"
 if [[ "${EBVERSIONGENTOO:-2017}" == "2023" ]]; then
-	EXCLUDE_PYTHON_VERSIONS="/2\.\|/3.[56789]"
+	EXCLUDE_PYTHON_VERSIONS="/2\.\|/3.[56789]\|3.10"
 fi
 
 function ls_pythons()


### PR DESCRIPTION
- [x] Exclude 3.10 from default builds
- [x] Use cython 3.0.11
- [x] Use python-build-bundle 2025a
- [x] Numpy 2.1
- [x] Scipy
- [x] Pandas
- [x] Matplotlib