### PR TITLE
Use `/tmp` instead of `/shared_tmp` for `build_wheel.sh`

### DIFF
--- a/build_wheel.sh
+++ b/build_wheel.sh
@@ -601,7 +601,7 @@ function adjust_torch_requirements_based_on_link_info()
 }
 
 echo "Building wheel for $PACKAGE"
-WORKDIR=/shared_tmp/build_wheels_tmp.$$
+WORKDIR=/tmp/build_wheels_tmp.$$
 mkdir $WORKDIR
 log_command pushd $WORKDIR
 if [[ -z "$EBROOTGENTOO" ]]; then


### PR DESCRIPTION
Local disks are faster than NFS, especially when network load is high.